### PR TITLE
Remove cyclic dependencies between packages

### DIFF
--- a/camel-idea-plugin/src/main/java/org/apache/camel/idea/annotator/CamelEndpointAnnotator.java
+++ b/camel-idea-plugin/src/main/java/org/apache/camel/idea/annotator/CamelEndpointAnnotator.java
@@ -31,6 +31,7 @@ import org.apache.camel.catalog.CamelCatalog;
 import org.apache.camel.catalog.EndpointValidationResult;
 import org.apache.camel.idea.service.CamelCatalogService;
 import org.apache.camel.idea.service.CamelPreferenceService;
+import org.apache.camel.idea.service.QueryUtils;
 import org.apache.camel.idea.util.CamelIdeaUtils;
 import org.apache.camel.idea.util.IdeaUtils;
 import org.jetbrains.annotations.NotNull;
@@ -55,7 +56,7 @@ public class CamelEndpointAnnotator extends AbstractCamelAnnotator {
      * if the URI is not valid a error annotation is created and highlight the invalid value.
      */
     void validateText(@NotNull PsiElement element, @NotNull AnnotationHolder holder, @NotNull String uri) {
-        if (CamelIdeaUtils.isQueryContainingCamelComponent(element.getProject(), uri)) {
+        if (QueryUtils.isQueryContainingCamelComponent(element.getProject(), uri)) {
             CamelCatalog catalogService = ServiceManager.getService(element.getProject(), CamelCatalogService.class).get();
 
             IElementType type = element.getNode().getElementType();

--- a/camel-idea-plugin/src/main/java/org/apache/camel/idea/completion/CamelContributor.java
+++ b/camel-idea-plugin/src/main/java/org/apache/camel/idea/completion/CamelContributor.java
@@ -24,7 +24,6 @@ import com.intellij.codeInsight.completion.CompletionParameters;
 import com.intellij.codeInsight.completion.CompletionProvider;
 import com.intellij.codeInsight.completion.CompletionResultSet;
 import com.intellij.codeInsight.completion.CompletionUtil;
-import com.intellij.notification.NotificationGroup;
 import com.intellij.openapi.components.ServiceManager;
 import com.intellij.patterns.InitialPatternCondition;
 import com.intellij.patterns.PsiFilePattern;
@@ -44,8 +43,6 @@ import static org.apache.camel.idea.util.IdeaUtils.isFromFileType;
  * Extend this class to define what it should re-act on when using smart completion
  */
 public abstract class CamelContributor extends CompletionContributor {
-
-    public static final NotificationGroup CAMEL_NOTIFICATION_GROUP = NotificationGroup.balloonGroup("Apache Camel");
 
     private final List<CamelCompletionExtension> camelCompletionExtensions = new ArrayList<>();
 

--- a/camel-idea-plugin/src/main/java/org/apache/camel/idea/inspection/AbstractCamelInspection.java
+++ b/camel-idea-plugin/src/main/java/org/apache/camel/idea/inspection/AbstractCamelInspection.java
@@ -34,6 +34,7 @@ import org.apache.camel.catalog.SimpleValidationResult;
 import org.apache.camel.idea.annotator.CamelAnnotatorEndpointMessage;
 import org.apache.camel.idea.service.CamelCatalogService;
 import org.apache.camel.idea.service.CamelService;
+import org.apache.camel.idea.service.QueryUtils;
 import org.apache.camel.idea.util.CamelIdeaUtils;
 import org.apache.camel.idea.util.IdeaUtils;
 import org.apache.camel.idea.util.StringUtils;
@@ -117,7 +118,7 @@ public abstract class AbstractCamelInspection extends LocalInspectionTool {
         boolean hasSimple = text.contains("${") || text.contains("$simple{");
         if (hasSimple && CamelIdeaUtils.isCamelSimpleExpression(element)) {
             validateSimple(element, holder, text, isOnTheFly);
-        } else if (CamelIdeaUtils.isQueryContainingCamelComponent(element.getProject(), text)) {
+        } else if (QueryUtils.isQueryContainingCamelComponent(element.getProject(), text)) {
             validateEndpoint(element, holder, text, isOnTheFly);
         }
     }

--- a/camel-idea-plugin/src/main/java/org/apache/camel/idea/service/CamelService.java
+++ b/camel-idea-plugin/src/main/java/org/apache/camel/idea/service/CamelService.java
@@ -42,7 +42,9 @@ import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
+
 import com.intellij.notification.Notification;
+import com.intellij.notification.NotificationGroup;
 import com.intellij.notification.NotificationType;
 import com.intellij.openapi.Disposable;
 import com.intellij.openapi.components.ServiceManager;
@@ -59,7 +61,6 @@ import org.apache.camel.idea.util.IdeaUtils;
 import org.jetbrains.annotations.NotNull;
 
 import static org.apache.camel.catalog.CatalogHelper.loadText;
-import static org.apache.camel.idea.completion.CamelContributor.CAMEL_NOTIFICATION_GROUP;
 import static org.apache.camel.idea.util.IdeaUtils.newURLClassLoaderForLibrary;
 import static org.apache.camel.idea.util.XmlUtils.getChildNodeByTagName;
 import static org.apache.camel.idea.util.XmlUtils.loadDocument;
@@ -68,6 +69,8 @@ import static org.apache.camel.idea.util.XmlUtils.loadDocument;
  * Service access for Camel libraries
  */
 public class CamelService implements Disposable {
+
+    public static final NotificationGroup CAMEL_NOTIFICATION_GROUP = NotificationGroup.balloonGroup("Apache Camel");
 
     private static final Logger LOG = Logger.getInstance(CamelService.class);
 

--- a/camel-idea-plugin/src/main/java/org/apache/camel/idea/service/QueryUtils.java
+++ b/camel-idea-plugin/src/main/java/org/apache/camel/idea/service/QueryUtils.java
@@ -1,0 +1,41 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.idea.service;
+
+import com.intellij.openapi.components.ServiceManager;
+import com.intellij.openapi.project.Project;
+import org.apache.camel.idea.util.StringUtils;
+
+public final class QueryUtils {
+
+    private QueryUtils() {
+    }
+
+    /**
+     * Validate if the query contain a known camel component
+     */
+    public static boolean isQueryContainingCamelComponent(Project project, String query) {
+        // is this a possible Camel endpoint uri which we know
+        if (query != null && !query.isEmpty()) {
+            String componentName = StringUtils.asComponentName(query);
+            if (componentName != null && ServiceManager.getService(project, CamelCatalogService.class).get().findComponentNames().contains(componentName)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/camel-idea-plugin/src/main/java/org/apache/camel/idea/util/CamelIdeaUtils.java
+++ b/camel-idea-plugin/src/main/java/org/apache/camel/idea/util/CamelIdeaUtils.java
@@ -444,20 +444,6 @@ public final class CamelIdeaUtils {
     }
 
     /**
-     * Validate if the query contain a known camel component
-     */
-    public static boolean isQueryContainingCamelComponent(Project project, String query) {
-        // is this a possible Camel endpoint uri which we know
-        if (query != null && !query.isEmpty()) {
-            String componentName = StringUtils.asComponentName(query);
-            if (componentName != null && ServiceManager.getService(project, CamelCatalogService.class).get().findComponentNames().contains(componentName)) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    /**
      * Certain elements should be skipped for endpoint validation such as ActiveMQ brokerURL property and others.
      */
     public static boolean skipEndpointValidation(PsiElement element) {

--- a/readme.md
+++ b/readme.md
@@ -102,7 +102,7 @@ An alternative is to change the version in `camel-idea-plugin/pom.xml` file to u
 
 Linux or Mac users:
 
- > - Execute the script file `./install-intellij-libs.sh 2017.2 /Applications/IntelliJ\ IDEA\ CE.app/Contents /Users/joe/.m2` 
+ > - Execute the script file `./install-intellij-libs.sh 2017.2 /Applications/IntelliJ\ IDEA\ CE.app/Contents $HOME/.m2` 
   
 Windows:
 


### PR DESCRIPTION
we should keep an eye of dependencies between packages to avoid an unmaintainable-big-ball-of-mud-plugin. So I used structure101 to analyze dependencies between packages/classes and moved some methods to another location.
Please let me know if it doesn't make sense to move these methods to these classes.