### PR TITLE
Remove fat package and move two Utils classes to another location

### DIFF
--- a/camel-idea-plugin/src/main/java/org/apache/camel/idea/completion/contributor/CamelContributor.java
+++ b/camel-idea-plugin/src/main/java/org/apache/camel/idea/completion/contributor/CamelContributor.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.camel.idea.completion;
+package org.apache.camel.idea.completion.contributor;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -56,7 +56,7 @@ public abstract class CamelContributor extends CompletionContributor {
 
         private final List<CamelCompletionExtension> camelCompletionExtensions;
 
-        public EndpointCompletion(List<CamelCompletionExtension> camelCompletionExtensions) {
+        EndpointCompletion(List<CamelCompletionExtension> camelCompletionExtensions) {
             this.camelCompletionExtensions = camelCompletionExtensions;
         }
 
@@ -118,11 +118,11 @@ public abstract class CamelContributor extends CompletionContributor {
      * Add additional completion extension to process when the
      * {@link CompletionProvider#addCompletions(CompletionParameters, ProcessingContext, CompletionResultSet)} is called
      */
-    public void addCompletionExtension(CamelCompletionExtension provider) {
+    void addCompletionExtension(CamelCompletionExtension provider) {
         camelCompletionExtensions.add(provider);
     }
 
-    public List<CamelCompletionExtension> getCamelCompletionExtensions() {
+    List<CamelCompletionExtension> getCamelCompletionExtensions() {
         return camelCompletionExtensions;
     }
 

--- a/camel-idea-plugin/src/main/java/org/apache/camel/idea/completion/contributor/CamelGroovyReferenceContributor.java
+++ b/camel-idea-plugin/src/main/java/org/apache/camel/idea/completion/contributor/CamelGroovyReferenceContributor.java
@@ -14,23 +14,24 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.camel.idea.completion;
+package org.apache.camel.idea.completion.contributor;
 
 import com.intellij.codeInsight.completion.CompletionType;
-import org.apache.camel.idea.completion.extension.CamelPropertyPlaceholderSmartCompletionExtension;
+import com.intellij.psi.PsiFile;
+import org.apache.camel.idea.completion.extension.CamelEndpointSmartCompletionExtension;
 
 import static com.intellij.patterns.PlatformPatterns.psiElement;
 
 /**
- * Plugin to hook into the IDEA completion system, to setup smart completion for Camel property placeholders (eg {{foo}} style)
+ * Plugin to hook into the IDEA Groovy language, to setup Camel smart completion for editing Groovy source code.
  */
-public class CamelPropertyPlaceholderReferenceContributor extends CamelContributor {
+@Deprecated
+public class CamelGroovyReferenceContributor extends CamelContributor {
 
-    public CamelPropertyPlaceholderReferenceContributor() {
-        // add hook for smart completion for {{ }} placeholders
-        addCompletionExtension(new CamelPropertyPlaceholderSmartCompletionExtension());
+    public CamelGroovyReferenceContributor() {
+        addCompletionExtension(new CamelEndpointSmartCompletionExtension(false));
         extend(CompletionType.BASIC,
-                psiElement().notNull(), // this works anywhere
+                psiElement().and(psiElement().inside(PsiFile.class).inFile(matchFileType("groovy"))),
                 new EndpointCompletion(getCamelCompletionExtensions())
         );
     }

--- a/camel-idea-plugin/src/main/java/org/apache/camel/idea/completion/contributor/CamelJavaReferenceContributor.java
+++ b/camel-idea-plugin/src/main/java/org/apache/camel/idea/completion/contributor/CamelJavaReferenceContributor.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.camel.idea.completion;
+package org.apache.camel.idea.completion.contributor;
 
 import com.intellij.codeInsight.completion.CompletionType;
 import com.intellij.psi.PsiFile;
@@ -23,14 +23,14 @@ import org.apache.camel.idea.completion.extension.CamelEndpointSmartCompletionEx
 import static com.intellij.patterns.PlatformPatterns.psiElement;
 
 /**
- * Plugin to hook into the IDEA XML language, to setup Camel smart completion for editing XML source code.
+ * Plugin to hook into the IDEA Java language, to setup Camel smart completion for editing Java source code.
  */
-public class CamelXmlReferenceContributor extends CamelContributor {
+public class CamelJavaReferenceContributor extends CamelContributor {
 
-    public CamelXmlReferenceContributor() {
-        addCompletionExtension(new CamelEndpointSmartCompletionExtension(true));
+    public CamelJavaReferenceContributor() {
+        addCompletionExtension(new CamelEndpointSmartCompletionExtension(false));
         extend(CompletionType.BASIC,
-                psiElement().and(psiElement().inside(PsiFile.class).inFile(matchFileType("xml"))),
+                psiElement().and(psiElement().inside(PsiFile.class).inFile(matchFileType("java"))),
                 new EndpointCompletion(getCamelCompletionExtensions())
         );
     }

--- a/camel-idea-plugin/src/main/java/org/apache/camel/idea/completion/contributor/CamelKotlinReferenceContributor.java
+++ b/camel-idea-plugin/src/main/java/org/apache/camel/idea/completion/contributor/CamelKotlinReferenceContributor.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.camel.idea.completion;
+package org.apache.camel.idea.completion.contributor;
 
 import com.intellij.codeInsight.completion.CompletionType;
 import com.intellij.psi.PsiFile;

--- a/camel-idea-plugin/src/main/java/org/apache/camel/idea/completion/contributor/CamelPropertiesOrYamlFileReferenceContributor.java
+++ b/camel-idea-plugin/src/main/java/org/apache/camel/idea/completion/contributor/CamelPropertiesOrYamlFileReferenceContributor.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.camel.idea.completion;
+package org.apache.camel.idea.completion.contributor;
 
 import com.intellij.codeInsight.completion.CompletionType;
 import com.intellij.psi.PsiFile;
@@ -23,15 +23,15 @@ import org.apache.camel.idea.completion.extension.CamelEndpointSmartCompletionEx
 import static com.intellij.patterns.PlatformPatterns.psiElement;
 
 /**
- * Plugin to hook into the IDEA Scala language, to setup Camel smart completion for editing Scala source code.
+ * Plugin to hook into the IDEA completion system, to setup Camel smart completion for editing properties or yaml files.
  */
-@Deprecated
-public class CamelScalaReferenceContributor extends CamelContributor {
+public class CamelPropertiesOrYamlFileReferenceContributor extends CamelContributor {
 
-    public CamelScalaReferenceContributor() {
+    public CamelPropertiesOrYamlFileReferenceContributor() {
+        // also allow to setup camel endpoints in properties files
         addCompletionExtension(new CamelEndpointSmartCompletionExtension(false));
         extend(CompletionType.BASIC,
-                psiElement().and(psiElement().inside(PsiFile.class).inFile(matchFileType("scala"))),
+                psiElement().and(psiElement().inside(PsiFile.class).inFile(matchFileType("properties", "yaml", "yml"))),
                 new EndpointCompletion(getCamelCompletionExtensions())
         );
     }

--- a/camel-idea-plugin/src/main/java/org/apache/camel/idea/completion/contributor/CamelPropertyPlaceholderReferenceContributor.java
+++ b/camel-idea-plugin/src/main/java/org/apache/camel/idea/completion/contributor/CamelPropertyPlaceholderReferenceContributor.java
@@ -14,24 +14,23 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.camel.idea.completion;
+package org.apache.camel.idea.completion.contributor;
 
 import com.intellij.codeInsight.completion.CompletionType;
-import com.intellij.psi.PsiFile;
-import org.apache.camel.idea.completion.extension.CamelEndpointSmartCompletionExtension;
+import org.apache.camel.idea.completion.extension.CamelPropertyPlaceholderSmartCompletionExtension;
 
 import static com.intellij.patterns.PlatformPatterns.psiElement;
 
 /**
- * Plugin to hook into the IDEA completion system, to setup Camel smart completion for editing properties or yaml files.
+ * Plugin to hook into the IDEA completion system, to setup smart completion for Camel property placeholders (eg {{foo}} style)
  */
-public class CamelPropertiesOrYamlFileReferenceContributor extends CamelContributor {
+public class CamelPropertyPlaceholderReferenceContributor extends CamelContributor {
 
-    public CamelPropertiesOrYamlFileReferenceContributor() {
-        // also allow to setup camel endpoints in properties files
-        addCompletionExtension(new CamelEndpointSmartCompletionExtension(false));
+    public CamelPropertyPlaceholderReferenceContributor() {
+        // add hook for smart completion for {{ }} placeholders
+        addCompletionExtension(new CamelPropertyPlaceholderSmartCompletionExtension());
         extend(CompletionType.BASIC,
-                psiElement().and(psiElement().inside(PsiFile.class).inFile(matchFileType("properties", "yaml", "yml"))),
+                psiElement().notNull(), // this works anywhere
                 new EndpointCompletion(getCamelCompletionExtensions())
         );
     }

--- a/camel-idea-plugin/src/main/java/org/apache/camel/idea/completion/contributor/CamelScalaReferenceContributor.java
+++ b/camel-idea-plugin/src/main/java/org/apache/camel/idea/completion/contributor/CamelScalaReferenceContributor.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.camel.idea.completion;
+package org.apache.camel.idea.completion.contributor;
 
 import com.intellij.codeInsight.completion.CompletionType;
 import com.intellij.psi.PsiFile;
@@ -23,14 +23,15 @@ import org.apache.camel.idea.completion.extension.CamelEndpointSmartCompletionEx
 import static com.intellij.patterns.PlatformPatterns.psiElement;
 
 /**
- * Plugin to hook into the IDEA Java language, to setup Camel smart completion for editing Java source code.
+ * Plugin to hook into the IDEA Scala language, to setup Camel smart completion for editing Scala source code.
  */
-public class CamelJavaReferenceContributor extends CamelContributor {
+@Deprecated
+public class CamelScalaReferenceContributor extends CamelContributor {
 
-    public CamelJavaReferenceContributor() {
+    public CamelScalaReferenceContributor() {
         addCompletionExtension(new CamelEndpointSmartCompletionExtension(false));
         extend(CompletionType.BASIC,
-                psiElement().and(psiElement().inside(PsiFile.class).inFile(matchFileType("java"))),
+                psiElement().and(psiElement().inside(PsiFile.class).inFile(matchFileType("scala"))),
                 new EndpointCompletion(getCamelCompletionExtensions())
         );
     }

--- a/camel-idea-plugin/src/main/java/org/apache/camel/idea/completion/contributor/CamelXmlReferenceContributor.java
+++ b/camel-idea-plugin/src/main/java/org/apache/camel/idea/completion/contributor/CamelXmlReferenceContributor.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.camel.idea.completion;
+package org.apache.camel.idea.completion.contributor;
 
 import com.intellij.codeInsight.completion.CompletionType;
 import com.intellij.psi.PsiFile;
@@ -23,15 +23,14 @@ import org.apache.camel.idea.completion.extension.CamelEndpointSmartCompletionEx
 import static com.intellij.patterns.PlatformPatterns.psiElement;
 
 /**
- * Plugin to hook into the IDEA Groovy language, to setup Camel smart completion for editing Groovy source code.
+ * Plugin to hook into the IDEA XML language, to setup Camel smart completion for editing XML source code.
  */
-@Deprecated
-public class CamelGroovyReferenceContributor extends CamelContributor {
+public class CamelXmlReferenceContributor extends CamelContributor {
 
-    public CamelGroovyReferenceContributor() {
-        addCompletionExtension(new CamelEndpointSmartCompletionExtension(false));
+    public CamelXmlReferenceContributor() {
+        addCompletionExtension(new CamelEndpointSmartCompletionExtension(true));
         extend(CompletionType.BASIC,
-                psiElement().and(psiElement().inside(PsiFile.class).inFile(matchFileType("groovy"))),
+                psiElement().and(psiElement().inside(PsiFile.class).inFile(matchFileType("xml"))),
                 new EndpointCompletion(getCamelCompletionExtensions())
         );
     }

--- a/camel-idea-plugin/src/main/java/org/apache/camel/idea/completion/endpoint/CamelSmartCompletionEndpointOptions.java
+++ b/camel-idea-plugin/src/main/java/org/apache/camel/idea/completion/endpoint/CamelSmartCompletionEndpointOptions.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.camel.idea.completion;
+package org.apache.camel.idea.completion.endpoint;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/camel-idea-plugin/src/main/java/org/apache/camel/idea/completion/endpoint/CamelSmartCompletionEndpointValue.java
+++ b/camel-idea-plugin/src/main/java/org/apache/camel/idea/completion/endpoint/CamelSmartCompletionEndpointValue.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.camel.idea.completion;
+package org.apache.camel.idea.completion.endpoint;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/camel-idea-plugin/src/main/java/org/apache/camel/idea/completion/extension/CamelCompletionExtension.java
+++ b/camel-idea-plugin/src/main/java/org/apache/camel/idea/completion/extension/CamelCompletionExtension.java
@@ -19,7 +19,7 @@ package org.apache.camel.idea.completion.extension;
 import com.intellij.codeInsight.completion.CompletionParameters;
 import com.intellij.codeInsight.completion.CompletionResultSet;
 import com.intellij.util.ProcessingContext;
-import org.apache.camel.idea.completion.CamelContributor;
+import org.apache.camel.idea.completion.contributor.CamelContributor;
 import org.jetbrains.annotations.NotNull;
 
 /**

--- a/camel-idea-plugin/src/main/java/org/apache/camel/idea/completion/extension/CamelEndpointSmartCompletionExtension.java
+++ b/camel-idea-plugin/src/main/java/org/apache/camel/idea/completion/extension/CamelEndpointSmartCompletionExtension.java
@@ -36,9 +36,9 @@ import org.apache.camel.idea.util.IdeaUtils;
 import org.apache.camel.idea.util.StringUtils;
 import org.jetbrains.annotations.NotNull;
 
-import static org.apache.camel.idea.completion.CamelSmartCompletionEndpointOptions.addSmartCompletionSuggestionsContextPath;
-import static org.apache.camel.idea.completion.CamelSmartCompletionEndpointOptions.addSmartCompletionSuggestionsQueryParameters;
-import static org.apache.camel.idea.completion.CamelSmartCompletionEndpointValue.addSmartCompletionForEndpointValue;
+import static org.apache.camel.idea.completion.endpoint.CamelSmartCompletionEndpointOptions.addSmartCompletionSuggestionsContextPath;
+import static org.apache.camel.idea.completion.endpoint.CamelSmartCompletionEndpointOptions.addSmartCompletionSuggestionsQueryParameters;
+import static org.apache.camel.idea.completion.endpoint.CamelSmartCompletionEndpointValue.addSmartCompletionForEndpointValue;
 import static org.apache.camel.idea.util.IdeaUtils.isCaretAtEndOfLine;
 
 /**

--- a/camel-idea-plugin/src/main/java/org/apache/camel/idea/service/CamelCatalogService.java
+++ b/camel-idea-plugin/src/main/java/org/apache/camel/idea/service/CamelCatalogService.java
@@ -22,7 +22,6 @@ import com.intellij.openapi.Disposable;
 import org.apache.camel.catalog.CamelCatalog;
 import org.apache.camel.catalog.DefaultCamelCatalog;
 import org.apache.camel.catalog.DefaultVersionManager;
-import org.apache.camel.idea.util.CamelMavenVersionManager;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -42,7 +41,7 @@ public class CamelCatalogService implements Disposable {
         return instance;
     }
 
-    public boolean isInstantiated() {
+    boolean isInstantiated() {
         return instance != null;
     }
 
@@ -52,7 +51,7 @@ public class CamelCatalogService implements Disposable {
      * @param version the version to load
      * @param repos   any third party maven repositories
      */
-    public boolean loadVersion(@NotNull String version, @NotNull Map<String, String> repos) {
+    boolean loadVersion(@NotNull String version, @NotNull Map<String, String> repos) {
         // we should load a new version of the catalog, and therefor must discard the old version
         dispose();
         // use maven to be able to load the version dynamic

--- a/camel-idea-plugin/src/main/java/org/apache/camel/idea/service/CamelMavenVersionManager.java
+++ b/camel-idea-plugin/src/main/java/org/apache/camel/idea/service/CamelMavenVersionManager.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.camel.idea.util;
+package org.apache.camel.idea.service;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -33,7 +33,7 @@ import org.apache.camel.catalog.VersionManager;
  * A copy of {@link org.apache.camel.catalog.maven.MavenVersionManager.MavenVersionManager} until a bug is fixed in Camel 2.19.1 onwards
  * so we can use it directly.
  */
-public class CamelMavenVersionManager implements VersionManager {
+class CamelMavenVersionManager implements VersionManager {
 
     private final ClassLoader classLoader = new GroovyClassLoader();
     private String version;
@@ -41,23 +41,12 @@ public class CamelMavenVersionManager implements VersionManager {
     private String cacheDirectory;
 
     /**
-     * Configures the directory for the download cache.
-     * <p/>
-     * The default folder is <tt>USER_HOME/.groovy/grape</tt>
-     *
-     * @param directory the directory.
-     */
-    public void setCacheDirectory(String directory) {
-        this.cacheDirectory = directory;
-    }
-
-    /**
      * To add a 3rd party Maven repository.
      *
      * @param name the repository name
      * @param url  the repository url
      */
-    public void addMavenRepository(String name, String url) {
+    void addMavenRepository(String name, String url) {
         Map<String, Object> repo = new HashMap<>();
         repo.put("name", name);
         repo.put("root", url);

--- a/camel-idea-plugin/src/main/java/org/apache/camel/idea/service/CamelService.java
+++ b/camel-idea-plugin/src/main/java/org/apache/camel/idea/service/CamelService.java
@@ -61,16 +61,16 @@ import org.apache.camel.idea.util.IdeaUtils;
 import org.jetbrains.annotations.NotNull;
 
 import static org.apache.camel.catalog.CatalogHelper.loadText;
+import static org.apache.camel.idea.service.XmlUtils.getChildNodeByTagName;
+import static org.apache.camel.idea.service.XmlUtils.loadDocument;
 import static org.apache.camel.idea.util.IdeaUtils.newURLClassLoaderForLibrary;
-import static org.apache.camel.idea.util.XmlUtils.getChildNodeByTagName;
-import static org.apache.camel.idea.util.XmlUtils.loadDocument;
 
 /**
  * Service access for Camel libraries
  */
 public class CamelService implements Disposable {
 
-    public static final NotificationGroup CAMEL_NOTIFICATION_GROUP = NotificationGroup.balloonGroup("Apache Camel");
+    private static final NotificationGroup CAMEL_NOTIFICATION_GROUP = NotificationGroup.balloonGroup("Apache Camel");
 
     private static final Logger LOG = Logger.getInstance(CamelService.class);
 

--- a/camel-idea-plugin/src/main/java/org/apache/camel/idea/service/XmlUtils.java
+++ b/camel-idea-plugin/src/main/java/org/apache/camel/idea/service/XmlUtils.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.camel.idea.util;
+package org.apache.camel.idea.service;
 
 import java.io.InputStream;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -29,7 +29,7 @@ import org.jetbrains.annotations.NotNull;
 /**
  * XML and DOM utilities.
  */
-public final class XmlUtils {
+final class XmlUtils {
 
     private XmlUtils() {
     }
@@ -41,7 +41,7 @@ public final class XmlUtils {
      * @param validating whether to validate or not
      * @return the DOM
      */
-    public static @NotNull Document loadDocument(@NotNull InputStream is, boolean validating) throws Exception {
+    static @NotNull Document loadDocument(@NotNull InputStream is, boolean validating) throws Exception {
         DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
         dbf.setValidating(validating);
         return dbf.newDocumentBuilder().parse(is);
@@ -54,7 +54,7 @@ public final class XmlUtils {
      * @param name the name of the child node to find and return
      * @return the child node, or <tt>null</tt> if none found
      */
-    public static Node getChildNodeByTagName(Node node, String name) {
+    static Node getChildNodeByTagName(Node node, String name) {
         NodeList children = node.getChildNodes();
         if (children != null && children.getLength() > 0) {
             for (int i = 0; i < children.getLength(); i++) {

--- a/camel-idea-plugin/src/main/java/org/apache/camel/idea/util/IdeaUtils.java
+++ b/camel-idea-plugin/src/main/java/org/apache/camel/idea/util/IdeaUtils.java
@@ -202,7 +202,7 @@ public final class IdeaUtils {
      * Is the element from a java setter method (eg setBrokerURL) or from a XML configured <tt>bean</tt> style
      * configuration using <tt>property</tt> element.
      */
-    public static boolean isElementFromSetterProperty(@NotNull PsiElement element, @NotNull String setter) {
+    static boolean isElementFromSetterProperty(@NotNull PsiElement element, @NotNull String setter) {
         // java method call
         PsiMethodCallExpression call = PsiTreeUtil.getParentOfType(element, PsiMethodCallExpression.class);
         if (call != null) {
@@ -231,7 +231,7 @@ public final class IdeaUtils {
     /**
      * Is the element from a java annotation with the given name.
      */
-    public static boolean isElementFromAnnotation(@NotNull PsiElement element, @NotNull String annotationName) {
+    static boolean isElementFromAnnotation(@NotNull PsiElement element, @NotNull String annotationName) {
         // java method call
         PsiAnnotation ann = PsiTreeUtil.getParentOfType(element, PsiAnnotation.class, false);
         if (ann != null) {
@@ -343,7 +343,7 @@ public final class IdeaUtils {
      * @param fqnClassName the class name to match
      * @return <tt>true</tt> if the class is a type or subtype of the class name
      */
-    public static boolean isClassOrParentOf(@Nullable PsiClass target, @NotNull String fqnClassName) {
+    private static boolean isClassOrParentOf(@Nullable PsiClass target, @NotNull String fqnClassName) {
         if (target == null) {
             return false;
         }
@@ -361,7 +361,7 @@ public final class IdeaUtils {
      * @param constructorName the name of the constructor (eg class)
      * @return <tt>true</tt> if its a constructor call from the given name, <tt>false</tt> otherwise
      */
-    public static boolean isElementFromConstructor(@NotNull PsiElement element, @NotNull String constructorName) {
+    static boolean isElementFromConstructor(@NotNull PsiElement element, @NotNull String constructorName) {
         // java constructor
         PsiConstructorCall call = PsiTreeUtil.getParentOfType(element, PsiConstructorCall.class);
         if (call != null) {
@@ -380,7 +380,7 @@ public final class IdeaUtils {
      * @param methods  method call names
      * @return <tt>true</tt> if matched, <tt>false</tt> otherwise
      */
-    public static boolean isFromJavaMethodCall(PsiElement element, boolean fromRouteBuilder, String... methods) {
+    static boolean isFromJavaMethodCall(PsiElement element, boolean fromRouteBuilder, String... methods) {
         // java method call
         PsiMethodCallExpression call = PsiTreeUtil.getParentOfType(element, PsiMethodCallExpression.class);
         if (call != null) {
@@ -426,7 +426,7 @@ public final class IdeaUtils {
      * @param methods  xml tag names
      * @return <tt>true</tt> if matched, <tt>false</tt> otherwise
      */
-    public static boolean isFromXmlTag(@NotNull XmlTag xml, @NotNull String... methods) {
+    static boolean isFromXmlTag(@NotNull XmlTag xml, @NotNull String... methods) {
         String name = xml.getLocalName();
         return Arrays.stream(methods).anyMatch(name::equals);
     }
@@ -438,7 +438,7 @@ public final class IdeaUtils {
      * @param parentTag a special parent tag name to match first
      * @return <tt>true</tt> if matched, <tt>false</tt> otherwise
      */
-    public static boolean hasParentXmlTag(@NotNull XmlTag xml, @NotNull String parentTag) {
+    static boolean hasParentXmlTag(@NotNull XmlTag xml, @NotNull String parentTag) {
         XmlTag parent = xml.getParentTag();
         return parent != null && parent.getLocalName().equals(parentTag);
     }
@@ -572,7 +572,7 @@ public final class IdeaUtils {
      * @param methods  method call names
      * @return <tt>true</tt> if matched, <tt>false</tt> otherwise
      */
-    public static boolean isFromScalaMethod(PsiElement element, String... methods) {
+    static boolean isFromScalaMethod(PsiElement element, String... methods) {
         // need to walk a bit into the psi tree to find the element that holds the method call name
         // (yes we need to go up till 5 levels up to find the method call expression
         String kind = element.toString();
@@ -660,7 +660,7 @@ public final class IdeaUtils {
      * @param methods  method call names
      * @return <tt>true</tt> if matched, <tt>false</tt> otherwise
      */
-    public static boolean isFromKotlinMethod(PsiElement element, String... methods) {
+    static boolean isFromKotlinMethod(PsiElement element, String... methods) {
         // need to walk a bit into the psi tree to find the element that holds the method call name
         // (yes we need to go up till 6 levels up to find the method call expression
         String kind = element.toString();
@@ -700,7 +700,7 @@ public final class IdeaUtils {
         return StringUtil.unquoteString(text.replace(QUOT, "\"")).replaceAll("(^\\n\\s+|\\n\\s+$|\\n\\s+)|(\"\\s*\\+\\s*\")|(\"\\s*\\+\\s*\\n\\s*\"*)", "");
     }
 
-    public static int getCaretPositionInsidePsiElement(String stringLiteral) {
+    private static int getCaretPositionInsidePsiElement(String stringLiteral) {
         String hackVal = stringLiteral.toLowerCase();
 
         int hackIndex = hackVal.indexOf(CompletionUtil.DUMMY_IDENTIFIER.toLowerCase());

--- a/camel-idea-plugin/src/main/resources/META-INF/plugin.xml
+++ b/camel-idea-plugin/src/main/resources/META-INF/plugin.xml
@@ -68,12 +68,12 @@
     <applicationService serviceImplementation="org.apache.camel.idea.service.CamelPreferenceService"/>
 
     <!-- allow code completion of Camel endpoints-->
-    <completion.contributor language="JAVA" implementationClass="org.apache.camel.idea.completion.CamelJavaReferenceContributor"/>
-    <completion.contributor language="XML" implementationClass="org.apache.camel.idea.completion.CamelXmlReferenceContributor"/>
-    <completion.contributor language="Groovy" implementationClass="org.apache.camel.idea.completion.CamelGroovyReferenceContributor"/>
-    <completion.contributor language="kotlin" implementationClass="org.apache.camel.idea.completion.CamelKotlinReferenceContributor"/>
-    <completion.contributor language="Scala" implementationClass="org.apache.camel.idea.completion.CamelScalaReferenceContributor"/>
-    <completion.contributor language="any" implementationClass="org.apache.camel.idea.completion.CamelPropertiesOrYamlFileReferenceContributor"/>
+    <completion.contributor language="JAVA" implementationClass="org.apache.camel.idea.completion.contributor.CamelJavaReferenceContributor"/>
+    <completion.contributor language="XML" implementationClass="org.apache.camel.idea.completion.contributor.CamelXmlReferenceContributor"/>
+    <completion.contributor language="Groovy" implementationClass="org.apache.camel.idea.completion.contributor.CamelGroovyReferenceContributor"/>
+    <completion.contributor language="kotlin" implementationClass="org.apache.camel.idea.completion.contributor.CamelKotlinReferenceContributor"/>
+    <completion.contributor language="Scala" implementationClass="org.apache.camel.idea.completion.contributor.CamelScalaReferenceContributor"/>
+    <completion.contributor language="any" implementationClass="org.apache.camel.idea.completion.contributor.CamelPropertiesOrYamlFileReferenceContributor"/>
 
     <!-- puts the Camel icon in the gutter for each line that starts a Camel route -->
     <codeInsight.lineMarkerProvider language="JAVA" implementationClass="org.apache.camel.idea.gutter.CamelRouteLineMarkerProvider"/>
@@ -83,7 +83,7 @@
     <codeInsight.lineMarkerProvider language="Scala" implementationClass="org.apache.camel.idea.gutter.CamelRouteLineMarkerProvider"/>
 
     <!-- code completion of Camel property placeholders, eg {{foo}} style -->
-    <completion.contributor language="any" implementationClass="org.apache.camel.idea.completion.CamelPropertyPlaceholderReferenceContributor"/>
+    <completion.contributor language="any" implementationClass="org.apache.camel.idea.completion.contributor.CamelPropertyPlaceholderReferenceContributor"/>
 
     <!-- quick documentation for Camel endpoints -->
     <lang.documentationProvider language="JAVA" implementationClass="org.apache.camel.idea.documentation.CamelDocumentationProvider"

--- a/camel-idea-plugin/src/test/java/org/apache/camel/idea/service/XmlUtilsTest.java
+++ b/camel-idea-plugin/src/test/java/org/apache/camel/idea/service/XmlUtilsTest.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.camel.idea.util;
+package org.apache.camel.idea.service;
 
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;


### PR DESCRIPTION
- Remove fat package by grouping some classes in sub packages
- Moved two Util classes to the same package as the class which uses them and reduced the visiblity of these Utils classes