### PR TITLE
Add tests for documentation

### DIFF
--- a/camel-idea-plugin/src/main/java/org/apache/camel/idea/documentation/CamelDocumentationProvider.java
+++ b/camel-idea-plugin/src/main/java/org/apache/camel/idea/documentation/CamelDocumentationProvider.java
@@ -289,10 +289,10 @@ public class CamelDocumentationProvider extends DocumentationProviderEx implemen
             ComponentModel component = ModelHelper.generateComponentModel(json, false);
 
             // to build external links which points to github
-            String a = component.getArtifactId();
+            String artifactId = component.getArtifactId();
 
             String url;
-            if ("camel-core".equals(a)) {
+            if ("camel-core".equals(artifactId)) {
                 url = GITHUB_EXTERNAL_DOC_URL + "/camel-core/src/main/docs/" + name + "-component.adoc";
             } else {
                 url = GITHUB_EXTERNAL_DOC_URL + "/components/" + component.getArtifactId() + "/src/main/docs/" + name + "-component.adoc";

--- a/camel-idea-plugin/src/test/java/org/apache/camel/idea/documentation/CamelDocumentationProviderTestIT.java
+++ b/camel-idea-plugin/src/test/java/org/apache/camel/idea/documentation/CamelDocumentationProviderTestIT.java
@@ -106,7 +106,6 @@ public class CamelDocumentationProviderTestIT extends CamelLightCodeInsightFixtu
         String documentation = new CamelDocumentationProvider().generateDoc(element, null);
         assertNotNull(documentation);
         assertTrue(documentation.startsWith("<b>File Component</b><br/>The file component is used for reading or writing files.<br/>"));
-        System.out.println(documentation);
     }
 
     public void testHandleExternal() {

--- a/camel-idea-plugin/src/test/java/org/apache/camel/idea/documentation/CamelDocumentationProviderTestIT.java
+++ b/camel-idea-plugin/src/test/java/org/apache/camel/idea/documentation/CamelDocumentationProviderTestIT.java
@@ -16,14 +16,16 @@
  */
 package org.apache.camel.idea.documentation;
 
-import java.io.File;
-import java.io.IOException;
+import java.io.*;
 
 import com.intellij.ide.highlighter.JavaFileType;
 import com.intellij.openapi.util.io.FileUtil;
 import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.psi.PsiClass;
+import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiJavaFile;
+import com.intellij.psi.PsiLiteralExpression;
+import com.intellij.psi.PsiManager;
 import com.intellij.psi.PsiReference;
 import org.apache.camel.idea.CamelLightCodeInsightFixtureTestCaseIT;
 
@@ -32,14 +34,25 @@ import org.apache.camel.idea.CamelLightCodeInsightFixtureTestCaseIT;
  */
 public class CamelDocumentationProviderTestIT extends CamelLightCodeInsightFixtureTestCaseIT {
 
-    public String getJavaTestData() {
+    private String getJavaTestData() {
         return "public static class MyRouteBuilder extends RouteBuilder {\n"
-            + "        @Override\n"
-            + "        public void configure() throws Exception {\n"
-            + "            <caret>from(\"file:inbox?delete=true\")\n"
-            + "                .to(\"file:outbox\");\n"
-            + "        }\n"
-            + "    }";
+                + "        @Override\n"
+                + "        public void configure() throws Exception {\n"
+                + "            <caret>from(\"file:inbox?delete=true\")\n"
+                + "                .to(\"file:outbox\");\n"
+                + "        }\n"
+                + "    }";
+
+    }
+
+    private String getJavaTestData1() {
+        return "public static class MyRouteBuilder extends RouteBuilder {\n"
+                + "        @Override\n"
+                + "        public void configure() throws Exception {\n"
+                + "            from(\"file:inbox?<caret>\")\n"
+                + "                .to(\"file:outbox\");\n"
+                + "        }\n"
+                + "    }";
 
     }
 
@@ -57,7 +70,31 @@ public class CamelDocumentationProviderTestIT extends CamelLightCodeInsightFixtu
 
         String docInfo = new CamelDocumentationProvider().getQuickNavigateInfo(psiClass, referenceElement.getElement());
         assertNotNull(docInfo);
+        String s = exampleHtmlFileText(getTestName(true));
         assertEquals(exampleHtmlFileText(getTestName(true)), docInfo);
+    }
+
+    public void testGetUrlFor() {
+        assertNull(new CamelDocumentationProvider().getUrlFor(null, null));
+    }
+
+    public void testGenerateDoc() throws Exception {
+        myFixture.configureByText(JavaFileType.INSTANCE, getJavaTestData1());
+
+        PsiElement element = myFixture.findElementByText("\"file:inbox?\"", PsiLiteralExpression.class);
+        String componentName = "file";
+        String lookup = componentName + ":inbox?delete";
+        PsiManager manager = myFixture.getPsiManager();
+
+        PsiElement docInfo = new CamelDocumentationProvider().getDocumentationElementForLookupItem(manager, lookup, element);
+
+        String doc = new CamelDocumentationProvider().generateDoc(docInfo, null);
+        assertEquals(readExpectedFile(), doc);
+
+        String documentation = new CamelDocumentationProvider().generateDoc(element, null);
+        assertNotNull(documentation);
+        assertTrue(documentation.startsWith("<b>File Component</b><br/>The file component is used for reading or writing files.<br/>"));
+        System.out.println(documentation);
     }
 
     private PsiClass getTestClass() throws Exception {
@@ -69,4 +106,24 @@ public class CamelDocumentationProviderTestIT extends CamelLightCodeInsightFixtu
         return StringUtil.convertLineSeparators(FileUtil.loadFile(htmlPath).trim(), "");
     }
 
+    private String readExpectedFile() {
+        String fileContent = null;
+        try {
+            fileContent = getFileContent(new FileInputStream("src/test/resources/testData/expected_doc.xml"));
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        return fileContent;
+    }
+
+    private static String getFileContent(FileInputStream fis) throws IOException {
+        try (BufferedReader br = new BufferedReader(new InputStreamReader(fis))) {
+            StringBuilder sb = new StringBuilder();
+            String line;
+            while ((line = br.readLine()) != null) {
+                sb.append(line);
+            }
+            return sb.toString();
+        }
+    }
 }

--- a/camel-idea-plugin/src/test/java/org/apache/camel/idea/documentation/CamelDocumentationProviderTestIT.java
+++ b/camel-idea-plugin/src/test/java/org/apache/camel/idea/documentation/CamelDocumentationProviderTestIT.java
@@ -108,15 +108,6 @@ public class CamelDocumentationProviderTestIT extends CamelLightCodeInsightFixtu
         assertTrue(documentation.startsWith("<b>File Component</b><br/>The file component is used for reading or writing files.<br/>"));
     }
 
-    public void testHandleExternal() {
-        myFixture.configureByText(JavaFileType.INSTANCE, getJavaTestDataWithCursorAfterQuestionMark());
-
-        PsiElement element = myFixture.findElementByText("\"file:inbox?\"", PsiLiteralExpression.class);
-
-        assertFalse(new CamelDocumentationProvider().handleExternal(null, null));
-        assertTrue(new CamelDocumentationProvider().handleExternal(element, null));
-    }
-
     public void testHandleExternalLink() {
         myFixture.configureByText(JavaFileType.INSTANCE, getJavaTestDataWithCursorBeforeColon());
 

--- a/camel-idea-plugin/src/test/java/org/apache/camel/idea/documentation/CamelDocumentationProviderTestIT.java
+++ b/camel-idea-plugin/src/test/java/org/apache/camel/idea/documentation/CamelDocumentationProviderTestIT.java
@@ -38,7 +38,7 @@ import org.apache.camel.idea.CamelLightCodeInsightFixtureTestCaseIT;
  */
 public class CamelDocumentationProviderTestIT extends CamelLightCodeInsightFixtureTestCaseIT {
 
-    private String getJavaTestData() {
+    private String getJavaTestWithCursorBeforeCamelComponent() {
         return "public static class MyRouteBuilder extends RouteBuilder {\n"
                 + "        @Override\n"
                 + "        public void configure() throws Exception {\n"
@@ -46,7 +46,6 @@ public class CamelDocumentationProviderTestIT extends CamelLightCodeInsightFixtu
                 + "                .to(\"file:outbox\");\n"
                 + "        }\n"
                 + "    }";
-
     }
 
     private String getJavaTestDataWithCursorAfterQuestionMark() {
@@ -75,7 +74,7 @@ public class CamelDocumentationProviderTestIT extends CamelLightCodeInsightFixtu
     }
 
     public void testJavaClassQuickNavigateInfo() throws Exception {
-        myFixture.configureByText(JavaFileType.INSTANCE, getJavaTestData());
+        myFixture.configureByText(JavaFileType.INSTANCE, getJavaTestWithCursorBeforeCamelComponent());
 
         PsiClass psiClass = getTestClass();
         PsiReference referenceElement = myFixture.getReferenceAtCaretPosition();
@@ -108,6 +107,15 @@ public class CamelDocumentationProviderTestIT extends CamelLightCodeInsightFixtu
         assertNotNull(documentation);
         assertTrue(documentation.startsWith("<b>File Component</b><br/>The file component is used for reading or writing files.<br/>"));
         System.out.println(documentation);
+    }
+
+    public void testHandleExternal() {
+        myFixture.configureByText(JavaFileType.INSTANCE, getJavaTestDataWithCursorAfterQuestionMark());
+
+        PsiElement element = myFixture.findElementByText("\"file:inbox?\"", PsiLiteralExpression.class);
+
+        assertFalse(new CamelDocumentationProvider().handleExternal(null, null));
+        assertTrue(new CamelDocumentationProvider().handleExternal(element, null));
     }
 
     public void testHandleExternalLink() {

--- a/camel-idea-plugin/src/test/resources/testData/expected_doc.xml
+++ b/camel-idea-plugin/src/test/resources/testData/expected_doc.xml
@@ -1,0 +1,1 @@
+<strong>delete</strong><br/><br/><strong>Group: </strong>consumer<br/><strong>Type: </strong><tt>boolean</tt><br/><strong>Required: </strong>false<br/><strong>Default value: </strong>false<br/><br/><div>If true the file will be deleted after it is processed successfully.</div>


### PR DESCRIPTION
unforatunately I wasn't able to test handleExternal, because IntelliJ's BrowserUtil.browse() method call opens a new browser tab every time the test is executed and mocking this method call didn't work out for me :/