### PR TITLE
Upgrade idea 2017 3 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,8 @@ cache:
     - $HOME/.m2
 before_install:
     -  "mkdir idea"
-    -  "./download-unpack-intellij.sh 2017.2.6 idea idea-IC-172.4574.11 $HOME/.m2"
-    -  "./install-intellij-libs.sh 2017.2.6 idea $HOME/.m2"
+    -  "./download-unpack-intellij.sh 2017.3.2 idea idea-IC-173.4127.27 $HOME/.m2"
+    -  "./install-intellij-libs.sh 2017.3.2 idea $HOME/.m2"
 after_failure:
       - cat ./camel-idea-plugin/camel-idea-plugin/target/failsafe-reports/*.txt
       - cat ./camel-idea-plugin/camel-idea-plugin/target/surefire-reports/*.txt

--- a/camel-idea-plugin/pom.xml
+++ b/camel-idea-plugin/pom.xml
@@ -34,7 +34,7 @@
   </description>
 
   <properties>
-    <idea.version>2017.2.6</idea.version>
+    <idea.version>2017.3.2</idea.version>
     <idea.platform.prefix>-Didea.platform.prefix=Idea</idea.platform.prefix>
     <ij.plugin>true</ij.plugin>
     <argLine>
@@ -258,25 +258,25 @@
     </dependency>
     <dependency>
       <groupId>com.intellij</groupId>
-      <artifactId>netty-all-4.1.10.Final</artifactId>
+      <artifactId>netty-all-4.1.13.Final</artifactId>
       <version>${idea.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.intellij</groupId>
-      <artifactId>xercesImpl</artifactId>
+      <artifactId>common-image-3.2.1</artifactId>
       <version>${idea.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.intellij</groupId>
-      <artifactId>xml-apis</artifactId>
+      <artifactId>commons-imaging-1.0-RC</artifactId>
       <version>${idea.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.intellij</groupId>
-      <artifactId>streamex-0.6.2</artifactId>
+      <artifactId>streamex-0.6.5</artifactId>
       <version>${idea.version}</version>
       <scope>test</scope>
     </dependency>
@@ -348,7 +348,7 @@
     </dependency>
     <dependency>
       <groupId>com.intellij</groupId>
-      <artifactId>protobuf-2.5.0</artifactId>
+      <artifactId>protobuf-java-2.5.0</artifactId>
       <version>${idea.version}</version>
       <scope>test</scope>
     </dependency>
@@ -373,12 +373,6 @@
     <dependency>
       <groupId>com.intellij</groupId>
       <artifactId>icons</artifactId>
-      <version>${idea.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.intellij</groupId>
-      <artifactId>sanselan-0.98-snapshot</artifactId>
       <version>${idea.version}</version>
       <scope>test</scope>
     </dependency>

--- a/camel-idea-plugin/src/test/java/org/apache/camel/idea/CamelLightCodeInsightFixtureTestCaseIT.java
+++ b/camel-idea-plugin/src/test/java/org/apache/camel/idea/CamelLightCodeInsightFixtureTestCaseIT.java
@@ -20,6 +20,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
+
 import com.intellij.openapi.components.ServiceManager;
 import com.intellij.psi.PsiElement;
 import com.intellij.testFramework.PsiTestUtil;
@@ -47,16 +48,16 @@ public abstract class CamelLightCodeInsightFixtureTestCaseIT extends LightCodeIn
             e.printStackTrace();
         }
     }
+
     @Override
     protected void setUp() throws Exception {
         super.setUp();
         if (!ignoreCamelCoreLib) {
-            PsiTestUtil.addLibrary(myModule, "Maven: " + CAMEL_CORE_MAVEN_ARTIFACT, mavenArtifacts[0].getParent(), mavenArtifacts[0].getName());
+            PsiTestUtil.addLibrary(myFixture.getProjectDisposable(), myModule, "Maven: " + CAMEL_CORE_MAVEN_ARTIFACT, mavenArtifacts[0].getParent(), mavenArtifacts[0].getName());
         }
         disposeOnTearDown(ServiceManager.getService(myModule.getProject(), CamelCatalogService.class));
         disposeOnTearDown(ServiceManager.getService(myModule.getProject(), CamelService.class));
         ServiceManager.getService(myModule.getProject(), CamelService.class).setCamelPresent(true);
-
     }
 
     @Override
@@ -104,7 +105,7 @@ public abstract class CamelLightCodeInsightFixtureTestCaseIT extends LightCodeIn
         service.setHighlightCustomOptions(true);
 
         List<String> expectedIgnoredProperties = Arrays.asList("java.", "Logger.", "logger", "appender.", "rootLogger.",
-                "camel.springboot.", "camel.component.", "camel.dataformat.", "camel.language.");
+            "camel.springboot.", "camel.component.", "camel.dataformat.", "camel.language.");
         service.setIgnorePropertyList(expectedIgnoredProperties);
         service.setShowCamelIconInGutter(true);
         service.setScanThirdPartyComponents(true);

--- a/camel-idea-plugin/src/test/java/org/apache/camel/idea/gutter/GutterTestUtil.java
+++ b/camel-idea-plugin/src/test/java/org/apache/camel/idea/gutter/GutterTestUtil.java
@@ -27,12 +27,14 @@ import com.intellij.codeInsight.daemon.impl.LineMarkersPass;
 import com.intellij.lang.java.JavaLanguage;
 import com.intellij.navigation.GotoRelatedItem;
 import com.intellij.psi.PsiElement;
-import com.intellij.psi.PsiLiteralExpression;
+import com.intellij.psi.PsiJavaToken;
 import com.intellij.psi.PsiMethod;
+import com.intellij.psi.PsiMethodCallExpression;
 import com.intellij.psi.PsiVariable;
 import com.intellij.psi.impl.source.tree.java.PsiMethodCallExpressionImpl;
 import com.intellij.psi.util.PsiTreeUtil;
 import com.intellij.psi.xml.XmlTag;
+
 
 /**
  * Utility class to test the gutter navigation.
@@ -73,11 +75,11 @@ final class GutterTestUtil {
     /**
      * For the given gutters return all the gutter navigation targets that are {@link PsiMethodCallExpressionImpl} elements.
      */
-    static List<PsiMethodCallExpressionImpl> getGuttersWithJavaTarget(List<GotoRelatedItem> gutterList) {
+    static List<PsiMethodCallExpression> getGuttersWithJavaTarget(List<GotoRelatedItem> gutterList) {
         return gutterList
             .stream()
-            .filter(gotoRelatedItem -> gotoRelatedItem.getElement() instanceof PsiLiteralExpression)
-            .map(gotoRelatedItem -> (PsiMethodCallExpressionImpl) gotoRelatedItem.getElement().getParent().getParent())
+            .filter(gotoRelatedItem -> gotoRelatedItem.getElement() instanceof PsiJavaToken)
+            .map(gotoRelatedItem -> PsiTreeUtil.getParentOfType(gotoRelatedItem.getElement(), PsiMethodCallExpression.class))
             .collect(Collectors.toList());
     }
 

--- a/camel-idea-plugin/src/test/java/org/apache/camel/idea/gutter/JavaCamelRouteLineMarkerProviderTestIT.java
+++ b/camel-idea-plugin/src/test/java/org/apache/camel/idea/gutter/JavaCamelRouteLineMarkerProviderTestIT.java
@@ -23,7 +23,7 @@ import com.intellij.codeInsight.daemon.LineMarkerInfo;
 import com.intellij.navigation.GotoRelatedItem;
 import com.intellij.openapi.components.ServiceManager;
 import com.intellij.psi.PsiIdentifier;
-import com.intellij.psi.PsiLiteralExpression;
+import com.intellij.psi.PsiJavaToken;
 import org.apache.camel.idea.CamelLightCodeInsightFixtureTestCaseIT;
 import org.apache.camel.idea.service.CamelPreferenceService;
 import static org.apache.camel.idea.gutter.GutterTestUtil.getGutterNavigationDestinationElements;
@@ -49,9 +49,9 @@ public class JavaCamelRouteLineMarkerProviderTestIT extends CamelLightCodeInsigh
 
         LineMarkerInfo.LineMarkerGutterIconRenderer firstGutter = (LineMarkerInfo.LineMarkerGutterIconRenderer) gutters.get(0);
 
-        assertTrue(firstGutter.getLineMarkerInfo().getElement() instanceof PsiLiteralExpression);
-        assertEquals("The navigation start element doesn't match", "file:inbox",
-            ((PsiLiteralExpression) firstGutter.getLineMarkerInfo().getElement()).getValue());
+        assertTrue(firstGutter.getLineMarkerInfo().getElement() instanceof PsiJavaToken);
+        assertEquals("The navigation start element doesn't match", "\"file:inbox\"",
+            firstGutter.getLineMarkerInfo().getElement().getText());
 
 
         List<GotoRelatedItem> firstGutterTargets = getGutterNavigationDestinationElements(firstGutter);
@@ -62,9 +62,9 @@ public class JavaCamelRouteLineMarkerProviderTestIT extends CamelLightCodeInsigh
 
         LineMarkerInfo.LineMarkerGutterIconRenderer secondGutter = (LineMarkerInfo.LineMarkerGutterIconRenderer) gutters.get(1);
 
-        assertTrue(secondGutter.getLineMarkerInfo().getElement() instanceof PsiLiteralExpression);
-        assertEquals("The navigation start element doesn't match", "file:outbox",
-            ((PsiLiteralExpression) secondGutter.getLineMarkerInfo().getElement()).getValue());
+        assertTrue(secondGutter.getLineMarkerInfo().getElement() instanceof PsiJavaToken);
+        assertEquals("The navigation start element doesn't match", "\"file:outbox\"",
+            secondGutter.getLineMarkerInfo().getElement().getText());
 
         List<GotoRelatedItem> secondGutterTargets = getGutterNavigationDestinationElements(secondGutter);
         assertEquals("Navigation should have one target", 1, secondGutterTargets.size());
@@ -86,9 +86,9 @@ public class JavaCamelRouteLineMarkerProviderTestIT extends CamelLightCodeInsigh
 
         LineMarkerInfo.LineMarkerGutterIconRenderer firstGutter = (LineMarkerInfo.LineMarkerGutterIconRenderer) gutters.get(0);
 
-        assertTrue(firstGutter.getLineMarkerInfo().getElement() instanceof PsiLiteralExpression);
-        assertEquals("The navigation start element doesn't match", "file:test",
-            ((PsiLiteralExpression) firstGutter.getLineMarkerInfo().getElement()).getValue());
+        assertTrue(firstGutter.getLineMarkerInfo().getElement() instanceof PsiJavaToken);
+        assertEquals("The navigation start element doesn't match", "\"file:test\"",
+            firstGutter.getLineMarkerInfo().getElement().getText());
 
 
         List<GotoRelatedItem> firstGutterTargets = getGutterNavigationDestinationElements(firstGutter);
@@ -99,9 +99,9 @@ public class JavaCamelRouteLineMarkerProviderTestIT extends CamelLightCodeInsigh
 
         LineMarkerInfo.LineMarkerGutterIconRenderer secondGutter = (LineMarkerInfo.LineMarkerGutterIconRenderer) gutters.get(1);
 
-        assertTrue(secondGutter.getLineMarkerInfo().getElement() instanceof PsiLiteralExpression);
-        assertEquals("The navigation start element doesn't match", "file:test",
-            ((PsiLiteralExpression) secondGutter.getLineMarkerInfo().getElement()).getValue());
+        assertTrue(secondGutter.getLineMarkerInfo().getElement() instanceof PsiJavaToken);
+        assertEquals("The navigation start element doesn't match", "\"file:test\"",
+            secondGutter.getLineMarkerInfo().getElement().getText());
 
         List<GotoRelatedItem> secondGutterTargets = getGutterNavigationDestinationElements(secondGutter);
         assertEquals("Navigation should have one target", 1, secondGutterTargets.size());

--- a/camel-idea-plugin/src/test/java/org/apache/camel/idea/gutter/MultiLanguageCamelRouteLineMarkerProviderTestIT.java
+++ b/camel-idea-plugin/src/test/java/org/apache/camel/idea/gutter/MultiLanguageCamelRouteLineMarkerProviderTestIT.java
@@ -20,9 +20,11 @@ import java.util.List;
 import com.intellij.codeInsight.daemon.GutterMark;
 import com.intellij.codeInsight.daemon.LineMarkerInfo;
 import com.intellij.navigation.GotoRelatedItem;
-import com.intellij.psi.PsiLiteralExpression;
+import com.intellij.psi.PsiJavaToken;
 import com.intellij.psi.xml.XmlToken;
 import org.apache.camel.idea.CamelLightCodeInsightFixtureTestCaseIT;
+
+
 import static org.apache.camel.idea.gutter.GutterTestUtil.getGuttersWithJavaTarget;
 import static org.apache.camel.idea.gutter.GutterTestUtil.getGuttersWithXMLTarget;
 
@@ -47,9 +49,9 @@ public class MultiLanguageCamelRouteLineMarkerProviderTestIT extends CamelLightC
 
         //from Java to XML
         LineMarkerInfo.LineMarkerGutterIconRenderer firstJavaGutter = (LineMarkerInfo.LineMarkerGutterIconRenderer) javaGutters.get(0);
-        assertTrue(firstJavaGutter.getLineMarkerInfo().getElement() instanceof PsiLiteralExpression);
-        assertEquals("The navigation start element doesn't match", "file:inbox",
-                ((PsiLiteralExpression) firstJavaGutter.getLineMarkerInfo().getElement()).getValue());
+        assertTrue(firstJavaGutter.getLineMarkerInfo().getElement() instanceof PsiJavaToken);
+        assertEquals("The navigation start element doesn't match", "\"file:inbox\"",
+            firstJavaGutter.getLineMarkerInfo().getElement().getText());
 
 
         List<GotoRelatedItem> firstJavaGutterTargets = GutterTestUtil.getGutterNavigationDestinationElements(firstJavaGutter);
@@ -61,8 +63,8 @@ public class MultiLanguageCamelRouteLineMarkerProviderTestIT extends CamelLightC
         //from XML to Java
         LineMarkerInfo.LineMarkerGutterIconRenderer firstXmlGutter = (LineMarkerInfo.LineMarkerGutterIconRenderer) xmlGutters.get(0);
         assertTrue(firstXmlGutter.getLineMarkerInfo().getElement() instanceof XmlToken);
-        assertEquals("The navigation start element doesn't match", "file:inbox",
-                ((PsiLiteralExpression) firstJavaGutter.getLineMarkerInfo().getElement()).getValue());
+        assertEquals("The navigation start element doesn't match", "\"file:inbox\"",
+                (firstJavaGutter.getLineMarkerInfo().getElement()).getText());
 
 
         List<GotoRelatedItem> firstXmlGutterTargets = GutterTestUtil.getGutterNavigationDestinationElements(firstXmlGutter);

--- a/camel-idea-plugin/src/test/java/org/apache/camel/idea/util/IdeaUtilsSkipEndpointValidationTestIT.java
+++ b/camel-idea-plugin/src/test/java/org/apache/camel/idea/util/IdeaUtilsSkipEndpointValidationTestIT.java
@@ -16,7 +16,6 @@
  */
 package org.apache.camel.idea.util;
 
-import java.io.File;
 import java.util.stream.Stream;
 import com.intellij.openapi.components.ServiceManager;
 import com.intellij.psi.PsiElement;
@@ -26,7 +25,8 @@ import org.apache.camel.idea.CamelLightCodeInsightFixtureTestCaseIT;
 import org.apache.camel.idea.service.CamelService;
 import org.jboss.shrinkwrap.resolver.api.maven.Maven;
 
-public class IdeaUtilsSkipEndointValidationTestIT extends CamelLightCodeInsightFixtureTestCaseIT {
+
+public class IdeaUtilsSkipEndpointValidationTestIT extends CamelLightCodeInsightFixtureTestCaseIT {
 
     private static final String ACTIVEMQ_ARTIFACT = "org.apache.activemq:activemq-camel:5.14.3";
     
@@ -56,8 +56,7 @@ public class IdeaUtilsSkipEndointValidationTestIT extends CamelLightCodeInsightF
         Stream.of(
             Maven.resolver().resolve(ACTIVEMQ_ARTIFACT)
                 .withTransitivity().asFile()
-        ).map(File::getAbsolutePath)
-            .forEach(path -> PsiTestUtil.addLibrary(myFixture.getModule(), path));
+        ).forEach(f -> PsiTestUtil.addLibrary(myFixture.getProjectDisposable(), myFixture.getModule(), f.getName(), f.getParentFile().getAbsolutePath(), f.getName()));
     }
 
     public void testShouldSkipActiveMQComponentFactoryMethod() {

--- a/readme.md
+++ b/readme.md
@@ -100,7 +100,7 @@ Second you need to install the IntelliJ libraries into your local maven reposito
 is the version of the IDEA you have installed locally, second is the locations of the IDEA.
 If you have installed IDEA in a different location than shown in the sample below, then make sure to use the correct path.
 
-Currently we use IDEA 2017.2.6 as the version and therefore you should download and use that version.
+Currently we use IDEA 2017.3.2 as the version and therefore you should download and use that version.
 An alternative is to change the version in `camel-idea-plugin/pom.xml` file to use a different version but its not recommended.
 
 Linux or Mac users:


### PR DESCRIPTION
This fix a few issues after upgrading IDEA SDK to 2017.3.2
- RelatedItemLineMarkerProvider has been a lot more restrict then previous. It now require to return smallest possible elements in the PSI tree for CamelRouteLineMarkerProvider
- Dispose test libraries add with PsiTestUtil.addLibrary  
