### PR TITLE
Disable soft reference for bean methods reference.

### DIFF
--- a/camel-idea-plugin/src/main/java/org/apache/camel/idea/refereance/CamelBeanMethodReference.java
+++ b/camel-idea-plugin/src/main/java/org/apache/camel/idea/refereance/CamelBeanMethodReference.java
@@ -106,6 +106,6 @@ public class CamelBeanMethodReference extends PsiReferenceBase<PsiClass> impleme
 
     @Override
     public boolean isSoft() {
-        return true;
+        return false;
     }
 }

--- a/camel-idea-plugin/src/test/java/org/apache/camel/idea/completion/JavaCamelBeanReferenceSmartCompletionTestIT.java
+++ b/camel-idea-plugin/src/test/java/org/apache/camel/idea/completion/JavaCamelBeanReferenceSmartCompletionTestIT.java
@@ -123,6 +123,15 @@ public class JavaCamelBeanReferenceSmartCompletionTestIT extends CamelLightCodeI
         assertThat(strings, Matchers.not(Matchers.contains("thisIsVeryPrivate")));
     }
 
+    public void testJavaBeanTestDataCompletionWithCaretInsideMultipleMethodRef() {
+        myFixture.configureByFiles("CompleteJavaBeanRoute5TestData.java", "CompleteJavaBeanMultipleMethodTestData.java",
+            "CompleteJavaBeanSuperClassTestData.java", "CompleteJavaBeanMethodPropertyTestData.properties");
+        myFixture.complete(CompletionType.BASIC, 1);
+        List<String> strings = myFixture.getLookupElementStrings();
+        assertEquals(3, strings.size());
+        assertThat(strings, Matchers.hasItems("multipleMethodsWithAnotherName", "multipleMethodsWithSameName", "multipleMethodsWithSameName"));
+    }
+
     public void testJavaBeanTestDataCompletionFile() {
         myFixture.configureByFiles("CompleteJavaBeanRouteTestData.java", "CompleteJavaBeanTestData.java", "CompleteJavaBeanSuperClassTestData.java");
         myFixture.complete(CompletionType.BASIC, 1);

--- a/camel-idea-plugin/src/test/java/org/apache/camel/idea/reference/JavaCamelBeanMethodReferenceTest.java
+++ b/camel-idea-plugin/src/test/java/org/apache/camel/idea/reference/JavaCamelBeanMethodReferenceTest.java
@@ -1,0 +1,52 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.idea.reference;
+
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.ResolveResult;
+import org.apache.camel.idea.CamelLightCodeInsightFixtureTestCaseIT;
+import org.apache.camel.idea.refereance.CamelBeanMethodReference;
+
+/**
+ * Test method reference link between the Java Camel DSL bean reference method @{code bean(MyClass.class,"myMethodName")}
+ */
+public class JavaCamelBeanMethodReferenceTest extends CamelLightCodeInsightFixtureTestCaseIT {
+
+    public void testCamelMethodReference() {
+        myFixture.configureByFiles("CompleteJavaBeanRoute3TestData.java", "CompleteJavaBeanTestData.java",
+            "CompleteJavaBeanSuperClassTestData.java", "CompleteJavaBeanMethodPropertyTestData.properties");
+        PsiElement element = myFixture.getFile().findElementAt(myFixture.getCaretOffset()).getParent();
+        final ResolveResult[] resolveResults = ((CamelBeanMethodReference) element.getReferences()[0]).multiResolve(false);
+        assertEquals(1, resolveResults.length);
+        assertEquals("public void letsDoThis() {}",  resolveResults[0].getElement().getText());
+    }
+
+    public void testCamelMultipleMethodReference() {
+        myFixture.configureByFiles("CompleteJavaBeanRoute4TestData.java", "CompleteJavaBeanMultipleMethodTestData.java", "CompleteJavaBeanSuperClassTestData.java");
+        PsiElement element = myFixture.getFile().findElementAt(myFixture.getCaretOffset()).getParent();
+        final ResolveResult[] resolveResults = ((CamelBeanMethodReference) element.getReferences()[0]).multiResolve(false);
+        assertEquals(2, resolveResults.length);
+        assertEquals("public void multipleMethodsWithSameName() { }",  resolveResults[0].getElement().getText());
+        assertEquals("public void multipleMethodsWithSameName(int data) { }",  resolveResults[1].getElement().getText());
+    }
+
+    public void testCamelNoMethodReference() {
+        myFixture.configureByFiles("CompleteJavaBeanRoute4TestData.java");
+        PsiElement element = myFixture.getFile().findElementAt(myFixture.getCaretOffset()).getParent();
+        assertEquals(0, element.getReferences().length);
+    }
+}

--- a/camel-idea-plugin/src/test/resources/testData/CompleteJavaBeanMethodPropertyTestData.properties
+++ b/camel-idea-plugin/src/test/resources/testData/CompleteJavaBeanMethodPropertyTestData.properties
@@ -1,0 +1,6 @@
+letsDoThis=should not show up as method reference
+property1=property1
+property2=property2
+property3=property3
+property4=property4
+property5=property5

--- a/camel-idea-plugin/src/test/resources/testData/CompleteJavaBeanMultipleMethodTestData.java
+++ b/camel-idea-plugin/src/test/resources/testData/CompleteJavaBeanMultipleMethodTestData.java
@@ -1,0 +1,27 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import testData.CompleteJavaBeanSuperClassTestData;
+
+public class CompleteJavaBeanMultipleMethodTestData extends CompleteJavaBeanSuperClassTestData {
+
+    public void multipleMethodsWithAnotherName() { }
+
+    public void multipleMethodsWithSameName() { }
+
+    public void multipleMethodsWithSameName(int data) { }
+
+}

--- a/camel-idea-plugin/src/test/resources/testData/CompleteJavaBeanRoute3TestData.java
+++ b/camel-idea-plugin/src/test/resources/testData/CompleteJavaBeanRoute3TestData.java
@@ -1,0 +1,29 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.main.Main;
+import testData.CompleteJavaBeanTestData;
+
+public final class CompleteJavaBeanRoute3TestData extends RouteBuilder {
+
+    @Override
+    public void configure() {
+        from("file:inbox")
+            .bean(CompleteJavaBeanTestData.class, "lets<caret>DoThis")
+            .to("log:out");
+    }
+}

--- a/camel-idea-plugin/src/test/resources/testData/CompleteJavaBeanRoute4TestData.java
+++ b/camel-idea-plugin/src/test/resources/testData/CompleteJavaBeanRoute4TestData.java
@@ -1,0 +1,29 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.main.Main;
+import testData.CompleteJavaBeanMultipleMethodTestData;
+
+public final class CompleteJavaBeanRoute4TestData extends RouteBuilder {
+
+    @Override
+    public void configure() {
+        from("file:inbox")
+            .bean(CompleteJavaBeanMultipleMethodTestData.class, "multipleMethodsWith<caret>SameName")
+            .to("log:out");
+    }
+}

--- a/camel-idea-plugin/src/test/resources/testData/CompleteJavaBeanRoute5TestData.java
+++ b/camel-idea-plugin/src/test/resources/testData/CompleteJavaBeanRoute5TestData.java
@@ -1,0 +1,29 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.main.Main;
+import testData.CompleteJavaBeanMultipleMethodTestData;
+
+public final class CompleteJavaBeanRoute5TestData extends RouteBuilder {
+
+    @Override
+    public void configure() {
+        from("file:inbox")
+            .bean(CompleteJavaBeanMultipleMethodTestData.class, "multipleMethods<caret>")
+            .to("log:out");
+    }
+}


### PR DESCRIPTION
This solve the issue with method reference in Camel DSL is also
linked to any matching property names. So when jump to declaration
it would also present choices found in properties files